### PR TITLE
Support `ghc-9.12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686377527,
-        "narHash": "sha256-kNmHI3RvbWj+ntPP+O+nOTnOcBRNPjcMiUwO8TNt0/Q=",
-        "owner": "NixOS",
+        "lastModified": 1755660401,
+        "narHash": "sha256-Zgy/k78SU7S9UkX/w0RtuK/hoQnXTkKh4grfRqsmHKo=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "47c9ecbac352ce4a90f0ceca2c0f801500febfd7",
+        "rev": "5788de501b965d7413f2beaac10aeeb56f9a19a8",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,5 @@
 {
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
@@ -25,9 +26,20 @@
         lib = {
           inherit mkCradle;
         };
-        packages = {
-          default = lib.mkCradle pkgs.haskellPackages;
-        };
+        packages =
+          (if system == "x86_64-linux"
+          then {
+            withGhc9_02 = lib.mkCradle pkgs.haskell.packages.ghc92;
+          }
+          else { })
+          //
+          {
+            withGhc9_04 = lib.mkCradle pkgs.haskell.packages.ghc94;
+            withGhc9_06 = lib.mkCradle pkgs.haskell.packages.ghc96;
+            withGhc9_10 = lib.mkCradle pkgs.haskell.packages.ghc910;
+            withGhc9_12 = lib.mkCradle pkgs.haskell.packages.ghc912;
+            default = lib.mkCradle pkgs.haskellPackages;
+          };
         checks = {
           hlint = pkgs.runCommand "hlint" { buildInputs = [ pkgs.hlint ]; }
             ''

--- a/src/Cradle.hs
+++ b/src/Cradle.hs
@@ -39,6 +39,7 @@
 --
 -- >>> run_ $ cmd "echo foo bar"
 -- *** Exception: echo foo bar: Cradle.run: posix_spawnp: does not exist (No such file or directory)
+-- ...
 --
 -- This is trying to run an executable with the file name @"echo foo"@, which
 -- doesn't exist. If you want to split up arguments automatically, you can do


### PR DESCRIPTION
This PR also

- bumps the `nixpkgs` version,
- adds packages (for checking on CI) for different ghc versions,
- removes the ci check on darwin for `ghc-9.2`. This compiler is not cached anywhere for the bumped nixpkgs version, so I thought it'd be fine to remove.